### PR TITLE
Create Table Scripts for: users, users_sessions

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,5 +1,5 @@
-PORT=3000
 DB_USER=''
 DB_HOST=''
 DB=''
 DB_PASS=''
+DB_PORT=''

--- a/server/database/config/index.js
+++ b/server/database/config/index.js
@@ -1,0 +1,14 @@
+require('dotenv').config();
+const { Pool, Client } = require('pg');
+const db = new Pool({
+  user: process.env.DB_USER,
+  host: process.env.DB_HOST,
+  database: process.env.DB,
+  password: process.env.DB_PASS,
+  port: parseInt(process.env.DB_PORT),
+})
+
+db.connect();
+
+module.exports = db;
+

--- a/server/database/scripts/createSessions.js
+++ b/server/database/scripts/createSessions.js
@@ -1,0 +1,20 @@
+const db = require('../config/index');
+
+const createTableQuery = `
+CREATE TABLE users_session (
+  id SERIAL PRIMARY KEY,
+  session VARCHAR(64) NOT NULL,
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  expires_at TIMESTAMP WITH TIME ZONE DEFAULT (CURRENT_TIMESTAMP + INTERVAL '24 hours'),
+  CONSTRAINT session_expiration CHECK (expires_at > created_at)
+);
+`;
+
+db.query(createTableQuery)
+  .then(() => {
+    console.log('success at create users_sessions')
+  })
+  .catch((err) => {
+    console.error(err);
+  })

--- a/server/database/scripts/createUser.js
+++ b/server/database/scripts/createUser.js
@@ -1,0 +1,23 @@
+const db = require('../config/index');
+
+const createTableQuery = `
+  CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    first_name VARCHAR(255) NOT NULL,
+    last_name VARCHAR(255) NOT NULL,
+    username VARCHAR(255) UNIQUE,
+    profile_img VARCHAR(255),
+    bio TEXT,
+    salt VARCHAR(255) NOT NULL
+  );
+`;
+
+db.query(createTableQuery)
+.then (() => {
+  console.log('success at creating users table')
+})
+.catch((err) => {
+  console.error(err);
+})

--- a/server/database/scripts/createUser.js
+++ b/server/database/scripts/createUser.js
@@ -8,7 +8,7 @@ const createTableQuery = `
     first_name VARCHAR(255) NOT NULL,
     last_name VARCHAR(255) NOT NULL,
     username VARCHAR(255) UNIQUE,
-    profile_img VARCHAR(255),
+    profile_img bytea,
     bio TEXT,
     salt VARCHAR(255) NOT NULL
   );


### PR DESCRIPTION
Changes:
- Removed extraneous port info form example.env (server is running on different port since client runs on 3000)
- Added a index.js in config file to connect to db once.
- Created users table in /scripts
- Create users_sessions in /scripts

Notes: 
- Followed thanh's schema with the exception of adding an extra column for salt
