### PR TITLE
CD / Test Remove old Images from EC2 During Deploy Step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           host: ${{ secrets.HOST }}
           username: ubuntu
-          key: ${{ secrets.PASSWORD }}
+          key: ${{ secrets.KEY }}
           script: |
             docker login
             docker image rm gbmytabc/quiz-whiz


### PR DESCRIPTION
Updated CD to remove old images before restarting the quiz-whiz container