### PR TITLE
Create quiz refactor

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,8 +9,6 @@ import Register from "../src/pages/Register";
 import UserProfilePage from './components/user-profile/UserProfilePage.jsx';
 import CreateQuiz from './components/create-quiz/CreateQuiz.jsx'
 
-
-
 function App() {
   return (
     <Router>
@@ -33,7 +31,6 @@ function App() {
         <Route path="/settings/" element={<UserProfilePage/>}></Route>
         <Route path='/createQuiz/' element={<CreateQuiz />}></Route>
       </Routes>
-
     </Router>
   );
 }

--- a/client/src/components/create-quiz/CreateQuiz.jsx
+++ b/client/src/components/create-quiz/CreateQuiz.jsx
@@ -1,6 +1,7 @@
 import "./styles/create-quiz.css";
 import { useState } from "react";
 import Categories from "./quiz-components/Categories.jsx";
+import Difficulty from "./quiz-components/Difficulty.jsx"
 import MCQuestions from "./quiz-components/MC-Questions.jsx";
 import TFQuestions from "./quiz-components/TF-Questions.jsx";
 import APIQuestions from "./quiz-components/API-Questions.jsx";
@@ -30,6 +31,11 @@ const CreateQuiz = (props) => {
    const [category4, setState4] = useState(false);
    const [category5, setState5] = useState(false);
    const [categoryVal, setCategoryVal] = useState(null);
+   // create state here to update difficulty selection
+   const [easyDiff, setEasyDiff] = useState(false);
+   const [mediumDiff, setMediumDiff] = useState(false);
+   const [hardDiff, setHardDiff] = useState(false);
+   const [difficulty, setDifficulty] = useState(null);
 
    // useState function
    const onSelect = (e) => {
@@ -63,14 +69,29 @@ const CreateQuiz = (props) => {
        setState4(true);
        setState5(false);
        setCategoryVal(e.target.name)
-     } else {
+     } else if (e.target.name === "category5") {
        setState1(false);
        setState2(false);
        setState3(false);
        setState4(false);
        setState5(true);
        setCategoryVal(e.target.name)
-     }
+     } else if (e.target.name === "easy") {
+        setEasyDiff(true)
+        setMediumDiff(false)
+        setHardDiff(false)
+        setDifficulty(e.target.name)
+     } else if (e.target.name === "medium") {
+        setEasyDiff(false)
+        setMediumDiff(true)
+        setHardDiff(false)
+        setDifficulty(e.target.name)
+    } else if (e.target.name === "hard") {
+        setEasyDiff(false)
+        setMediumDiff(false)
+        setHardDiff(true)
+        setDifficulty(e.target.name)
+    }
    };
 
     const handleFormChange = (e, index) => {
@@ -233,12 +254,15 @@ const CreateQuiz = (props) => {
           alert("Please Enter Quiz Name!")
         } else if (!categoryVal) {
           alert("Please Choose Category!")
+        } else if (!difficulty) {
+          alert("Please Select Difficulty!")
         } else {
           if (TF) {
             var quizDataTF = {
               quizzes: {
               user_id: "admin",
               name: quizName,
+              difficulty: difficulty,
               category: categoryVal
               },
               questions: JSON.stringify(TFInputFields),
@@ -252,11 +276,11 @@ const CreateQuiz = (props) => {
               body: JSON.stringify(quizDataTF),
             }
 
-            fetch("http://localhost:3000/create/createQuiz", optionsTF)
+            fetch("http://localhost:8080/create/createQuiz", optionsTF)
             .then( (response) => {
               if (response.status === 200) {
                 alert("Quiz Succesfully Created!");
-                window.location.href = "http:localhost:3000/";
+                window.location.href = process.env.REACT_APP_API_URI;
               }
             })
           } else if (MC) {
@@ -264,6 +288,7 @@ const CreateQuiz = (props) => {
               quizzes: {
               user_id: "admin",
               name: quizName,
+              difficulty: difficulty,
               category: categoryVal
               },
               questions: JSON.stringify(MCInputFields),
@@ -277,11 +302,11 @@ const CreateQuiz = (props) => {
               body: JSON.stringify(quizDataMC),
             }
 
-            fetch("http://localhost:3000/create/createQuiz", optionsMC)
+            fetch("http://localhost:8080/create/createQuiz", optionsMC)
             .then( (response) => {
               if (response.status === 200) {
                 alert("Quiz Succesfully Created!");
-                window.location.href = "http:localhost:3000/";
+                window.location.href = process.env.REACT_APP_API_URI;
               }
             })
           } else {
@@ -289,6 +314,7 @@ const CreateQuiz = (props) => {
               quizzes: {
               user_id: "admin",
               name: quizName,
+              difficulty: difficulty,
               category: categoryVal
               },
               questions: JSON.stringify(MCInputFields.concat(TFInputFields)),
@@ -302,11 +328,11 @@ const CreateQuiz = (props) => {
               body: JSON.stringify(quizDataMCTF)
             }
 
-            fetch("http://localhost:3000/create/createQuiz", optionsMCTF)
+            fetch("http://localhost:8080/create/createQuiz", optionsMCTF)
             .then( (response) => {
               if (response.status === 200) {
                 alert("Quiz Succesfully Created!");
-                window.location.href = "http:localhost:3000/";
+                window.location.href = process.env.REACT_APP_API_URI;
               }
             })
           }
@@ -331,6 +357,12 @@ const CreateQuiz = (props) => {
           category4={category4}
           category5={category5}
           select={onSelect}
+        />
+        <Difficulty
+        easyDiff={easyDiff}
+        mediumDiff={mediumDiff}
+        hardDiff={hardDiff}
+        select={onSelect}
         />
         <MCQuestions
           inputFields={MCInputFields}

--- a/client/src/components/create-quiz/CreateQuiz.jsx
+++ b/client/src/components/create-quiz/CreateQuiz.jsx
@@ -5,11 +5,15 @@ import Difficulty from "./quiz-components/Difficulty.jsx"
 import MCQuestions from "./quiz-components/MC-Questions.jsx";
 import TFQuestions from "./quiz-components/TF-Questions.jsx";
 import APIQuestions from "./quiz-components/API-Questions.jsx";
+import { useContext } from 'react'
+import { UserContext } from '../global/UserContext.jsx'
 
 // need useState here for both MC Questions and TF Questions
 // state will be passed down to both components along with update functions.
 
 const CreateQuiz = (props) => {
+
+  const { user } = useContext(UserContext);
 
    // useStates here
    const [quizName, setQuizName] = useState("");
@@ -48,6 +52,7 @@ const CreateQuiz = (props) => {
        setState4(false);
        setState5(false);
        setCategoryVal(e.target.name);
+       console.log(user);
      } else if (e.target.name === "category2") {
        setState1(false);
        setState2(true);
@@ -260,7 +265,7 @@ const CreateQuiz = (props) => {
           if (TF) {
             var quizDataTF = {
               quizzes: {
-              user_id: "admin",
+              user_id: user,
               name: quizName,
               difficulty: difficulty,
               category: categoryVal
@@ -286,7 +291,7 @@ const CreateQuiz = (props) => {
           } else if (MC) {
             var quizDataMC = {
               quizzes: {
-              user_id: "admin",
+              user_id: user,
               name: quizName,
               difficulty: difficulty,
               category: categoryVal
@@ -312,7 +317,7 @@ const CreateQuiz = (props) => {
           } else {
             var quizDataMCTF = {
               quizzes: {
-              user_id: "admin",
+              user_id: user,
               name: quizName,
               difficulty: difficulty,
               category: categoryVal

--- a/client/src/components/create-quiz/CreateQuiz.jsx
+++ b/client/src/components/create-quiz/CreateQuiz.jsx
@@ -52,7 +52,6 @@ const CreateQuiz = (props) => {
        setState4(false);
        setState5(false);
        setCategoryVal(e.target.name);
-       console.log(user);
      } else if (e.target.name === "category2") {
        setState1(false);
        setState2(true);
@@ -281,11 +280,11 @@ const CreateQuiz = (props) => {
               body: JSON.stringify(quizDataTF),
             }
 
-            fetch("http://localhost:8080/create/createQuiz", optionsTF)
+            fetch(`${process.env.REACT_APP_API_URI}/create/createQuiz`, optionsTF)
             .then( (response) => {
               if (response.status === 200) {
                 alert("Quiz Succesfully Created!");
-                window.location.href = process.env.REACT_APP_API_URI;
+                window.location.href = '/';
               }
             })
           } else if (MC) {
@@ -307,11 +306,11 @@ const CreateQuiz = (props) => {
               body: JSON.stringify(quizDataMC),
             }
 
-            fetch("http://localhost:8080/create/createQuiz", optionsMC)
+            fetch(`${process.env.REACT_APP_API_URI}/create/createQuiz`, optionsMC)
             .then( (response) => {
               if (response.status === 200) {
                 alert("Quiz Succesfully Created!");
-                window.location.href = process.env.REACT_APP_API_URI;
+                window.location.href = '/';
               }
             })
           } else {
@@ -333,11 +332,11 @@ const CreateQuiz = (props) => {
               body: JSON.stringify(quizDataMCTF)
             }
 
-            fetch("http://localhost:8080/create/createQuiz", optionsMCTF)
+            fetch(`${process.env.REACT_APP_API_URI}/create/createQuiz`, optionsMCTF)
             .then( (response) => {
               if (response.status === 200) {
                 alert("Quiz Succesfully Created!");
-                window.location.href = process.env.REACT_APP_API_URI;
+                window.location.href = '/';
               }
             })
           }

--- a/client/src/components/create-quiz/quiz-components/Difficulty.jsx
+++ b/client/src/components/create-quiz/quiz-components/Difficulty.jsx
@@ -1,0 +1,35 @@
+import "../styles/create-quiz.css";
+
+
+const Difficulty = (props) => {
+  return (
+    <div className="Diffictuly">
+      <button
+        name="easy"
+        className={`category${props.easyDiff ? "chosen" : ""}`}
+        onClick={props.select}
+      >
+        {" "}
+        Easy{" "}
+      </button>
+      <button
+        name="medium"
+        className={`category${props.mediumDiff ? "chosen" : ""}`}
+        onClick={props.select}
+      >
+        {" "}
+        Medium{" "}
+      </button>
+      <button
+        name="hard"
+        className={`category${props.hardDiff? "chosen" : ""}`}
+        onClick={props.select}
+      >
+        {" "}
+        Hard{" "}
+      </button>
+    </div>
+  );
+};
+
+export default Difficulty;

--- a/client/src/components/create-quiz/quiz-components/MC-Questions.jsx
+++ b/client/src/components/create-quiz/quiz-components/MC-Questions.jsx
@@ -4,6 +4,10 @@ const MCQuestions = (props) => {
   return (
     <div className="MCQuestions">
       <form>
+      <button name="MCButton" onClick={props.addFields}>
+          {" "}
+          Add More MC Questions!{" "}
+        </button>
         {props.inputFields.map((input, index) => {
           return (
             <div key={index}>
@@ -73,10 +77,6 @@ const MCQuestions = (props) => {
             </div>
           );
         })}
-        <button name="MCButton" onClick={props.addFields}>
-          {" "}
-          Add More MC Questions!{" "}
-        </button>
       </form>
     </div>
   );

--- a/client/src/components/create-quiz/quiz-components/TF-Questions.jsx
+++ b/client/src/components/create-quiz/quiz-components/TF-Questions.jsx
@@ -5,19 +5,40 @@ const TFQuestions = (props) => {
   return (
     <div className='TFQuestions'>
       <form>
+        <button
+        name='TFButton' onClick={props.addFields}>
+          {" "}
+          Add More TF Questions!{" "}
+        </button>
         {props.inputFields.map((input, index) => {
           return (
             <div key={index}>
-              <textarea name='question' value={props.inputFields[index]['question']} rows={4} cols={40} placeholder='Type Question Here' onChange={(e) => {props.handleFormChange(e, index)}}></textarea>
-              <button name='TFRemoveButton' onClick={(e) => {props.removeFields(e, index)}}> X </button>
+              <textarea
+                name='question'
+                value={props.inputFields[index]['question']}
+                rows={4}
+                cols={40}
+                placeholder='Type Question Here'
+                onChange={(e) => {props.handleFormChange(e, index)}}>
+              </textarea>
               <div name='answers'>
-                <input name='corrAns' value={props.inputFields[index]['corrAns']} placeholder='Correct Answer' onChange={(e) => {props.handleFormChange(e, index)}}></input>
-                <input name='incAns' value={props.inputFields[index]['incAns']} placeholder='Incorrect Answer' onChange={(e) => {props.handleFormChange(e, index)}}></input>
+                <input
+                  name='corrAns'
+                  value={props.inputFields[index]['corrAns']}
+                  placeholder='Correct Answer'
+                  onChange={(e) => {props.handleFormChange(e, index)}}>
+                </input>
+                <input
+                  name='incAns'
+                  value={props.inputFields[index]['incAns']}
+                  placeholder='Incorrect Answer'
+                  onChange={(e) => {props.handleFormChange(e, index)}}>
+                </input>
               </div>
             </div>
           )
         })}
-        <button name='TFButton' onClick={props.addFields}> Add More Questions! </button>
+
       </form>
     </div>
   );

--- a/client/src/components/create-quiz/quiz-components/TF-Questions.jsx
+++ b/client/src/components/create-quiz/quiz-components/TF-Questions.jsx
@@ -21,6 +21,15 @@ const TFQuestions = (props) => {
                 placeholder='Type Question Here'
                 onChange={(e) => {props.handleFormChange(e, index)}}>
               </textarea>
+              <button
+                name="TFRemoveButton"
+                onClick={(e) => {
+                  props.removeFields(e, index);
+                }}
+              >
+                {" "}
+                X{" "}
+              </button>
               <div name='answers'>
                 <input
                   name='corrAns'

--- a/client/src/components/create-quiz/styles/create-quiz.css
+++ b/client/src/components/create-quiz/styles/create-quiz.css
@@ -5,3 +5,7 @@
 textarea {
   resize: none;
 }
+
+.difficultychosen {
+  color: blue;
+}

--- a/server/controllers/create/quizzes.js
+++ b/server/controllers/create/quizzes.js
@@ -8,7 +8,7 @@ module.exports = {
 
     dbMethods.createQuiz(req.body, (err, result) => {
       if (err) {
-        console.log('failing at res.sendStatus(400)')
+        console.log('failing at res.sendStatus(400)', err)
         res.sendStatus(400);
       } else {
         res.sendStatus(200);

--- a/server/database/models/create/create-quiz.js
+++ b/server/database/models/create/create-quiz.js
@@ -4,7 +4,7 @@ let createQuiz = (data, callback) => {
   // db connection created, insert statement depending on what the data looks like
   var quizData = data.quizzes
   var questionsData = JSON.stringify(data.questions);
-  var quizzesQuery = `INSERT INTO quizzes (user_id, category, difficulty, quiz_name) VALUES ('${quizData.user_id}', '${quizData.category}', '${'easy'}', '${quizData.name}') RETURNING id`
+  var quizzesQuery = `INSERT INTO quizzes (user_id, category, difficulty, quiz_name) VALUES ('${quizData.user_id}', '${quizData.category}', '${quizData.difficulty}', '${quizData.name}') RETURNING id`
 
   db.query(quizzesQuery, (err, res) => {
     if (err) {
@@ -15,6 +15,7 @@ let createQuiz = (data, callback) => {
       var questionsQuery = `INSERT INTO questions (quiz_id, questions) VALUES ('${id}', '${questionsData}')`
       db.query(questionsQuery, (err, res) => {
         if (err) {
+          console.log(err);
           callback(err, null);
         } else {
           callback(null, true);

--- a/server/index.js
+++ b/server/index.js
@@ -6,15 +6,12 @@ const port = process.env.SERVER_PORT
 const { dashboard } = require('./routes');
 const expressSession = require('./middlewares/sessions');
 const { create } = require('./routes/index.js')
-const bodyParser = require('body-parser')
 const cors = require('cors');
 
 // =============================================
 //                Middleware
 // =============================================
 app.use(express.json());
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({extended: false}))
 app.use(expressSession);
 app.use(cors({origin: 'http://localhost:3000'}))
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.0",
-        "body-parser": "^1.20.2",
         "connect-pg-simple": "^8.0.0",
         "cors": "^2.8.5",
         "express": "^4.18.2",
@@ -2395,40 +2394,6 @@
       "engines": {
         "node": ">= 10.0.0"
       }
-    },
-    "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/body-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/ms": {
-      "version": "2.0.0",
-      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -4879,20 +4844,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/react-is": {

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "bcrypt": "^5.1.0",
     "connect-pg-simple": "^8.0.0",
-    "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "express-session": "^1.17.3",


### PR DESCRIPTION
Refactored both FE and BE. 

FE Refactor includes moving the buttons from rendering below the fields which would push the button down, to the top of the fields of their respective type. 

Also, difficulty buttons have been placed and utilize the same logic as category for selection and highlight of the difficulty chosen by the user. 

Validation has been updated to include difficulty as well. 

UserContext now available for Create Quiz Feature which allows for user to be accurate sent to database. Before it was hardcoded to "admin", but now it utilizes "guest" by default when logged out instead. We can use "guest" to pull quizzes from database under that user_id instead of "admin" in case client wants to use "admin" for other purposes. Guests won't be able to make quizzes anyways so we can use this account for sample quizzes. 

BE Refactor takes into account the new frontend additions. Backend now allows for chosen category and user_id to be placed into database instead of defaulting to "easy" and "admin." 

Body Parser removed as express.json() was working as intended. Issue unrelated to json parse. Issue already resolved in another manner. 